### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,7 @@
     "type": "git",
     "url": "git://github.com/tunnckoCore/express-better-ratelimit.git"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/tunnckoCore/express-better-ratelimit/blob/master/license.md"
-  },
+  "license": "MIT",
   "dependencies": {
     "ipchecker": "*"
   },


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)
